### PR TITLE
Improve create-widget-app

### DIFF
--- a/create-widget-app/README.md
+++ b/create-widget-app/README.md
@@ -4,50 +4,52 @@ Template app that creates a widget & react iframe.
 
 Code organization:
 
-| dir / path           | description                          |
-| -------------------- | ------------------------------------ |
-| ui-src/              | This is where the iframe code lives  |
-| ui-src/index.html    | Main entry point for the iframe code |
-| ui-src/tsconfig.json | tsconfig for the iframe code         |
-| code.tsx             | This is the widget code              |
-| tsconfig.json        | tsconfig for the widget code         |
-| dist/                | Built output goes here               |
+| dir / path               | description                          |
+| ------------------------ | ------------------------------------ |
+| ui-src/                  | This is where the iframe code lives  |
+| ui-src/index.html        | Main entry point for the iframe code |
+| ui-src/tsconfig.json     | tsconfig for the iframe code         |
+| widget-src/              | This is where the widget code lives  |
+| widget-src/code.tsx      | Main entry point for the widget code |
+| widget-src/tsconfig.json | tsconfig for the widget code         |
+| dist/                    | Built output goes here               |
 
-- The widget code just uses tsc directly like most of our plugin/widget samples
+- The widget code just uses esbuild to bundle widget-src/code.tsx into one file.
 - The iframe code uses a tool called [vite](https://vitejs.dev/) to bundle everything into a single html file
 
 ## Getting started
 
-
-### one-time setup
+### One-time setup
 1. Make a copy of this folder
 2. Update manifest.json, package.json and package-lock.json where it says `WidgetTemplate`
 3. Install the required dependencies `npm ci`
 
 
-### importing your widget
+### Importing your widget
 1. "Import widget from manifest"
 2. Build code `npm run build`
 3. Choose your manifest
 
-## iframe development
 
-Often the code in the iframe can get pretty complex, if helpful, you can also do
+## Development
 
+The quickest way to build your widget during development is by running:
+
+```sh
+npm run dev
 ```
-npm run dev:ui
-```
 
-- This command starts a development server that will serve the iframe code at http://localhost:3000
-- The development server will also hot reload any changes to your iframe code
+This command starts the follow in watch mode:
+1. typechecking for widget-src & ui-src
+2. bundling for widget-src & ui-src
+3. starts a vite dev server that servesr ui-src/index.html at localhost:3000
 
-
-## Scripts
+## Other scripts
 
 | script                   | description                                                             |
 | ------------------------ | ----------------------------------------------------------------------- |
 | npm run build            | one-off full build of both the iframe and widget                        |
+| npm run build:production | one-off full production (minified) build of both the iframe and widget  |
 | npm run build:main       | one-off build of the widget code                                        |
 | npm run build:ui         | one-off build of the iframe code                                        |
-| npm run build:main:watch | watch-mode build of the widget code. rebuilds if when you save changes. |
-| npm run build:ui:watch   | watch-mode build of the iframe code. rebuilds if when you save changes. |
+| npm run tsc              | typecheck both the iframe and widget                                    |

--- a/create-widget-app/package.json
+++ b/create-widget-app/package.json
@@ -3,18 +3,18 @@
   "version": "1.0.0",
   "description": "WidgetTemplate",
   "scripts": {
-    "test": "npm run typecheck && npm run build",
+    "test": "npm run tsc && npm run build",
     "format": "prettier --write .",
-    "typecheck": "npm run typecheck:main && npm run typecheck:ui",
-    "typecheck:main": "tsc --noEmit -p widget-src",
-    "typecheck:ui": "tsc --noEmit -p ui-src",
-    "typecheck:watch": "concurrently \"npm run typecheck:main -- --watch\" \"npm run typecheck:ui -- --watch\"",
+    "tsc": "npm run tsc:main && npm run tsc:ui",
+    "tsc:main": "tsc --noEmit -p widget-src",
+    "tsc:ui": "tsc --noEmit -p ui-src",
+    "tsc:watch": "concurrently -n widget,iframe \"npm run tsc:main -- --watch --preserveWatchOutput\" \"npm run tsc:ui -- --watch --preserveWatchOutput\"",
     "build": "npm run build:ui && npm run build:main",
     "build:production": "npm run build:ui && npm run build:main -- --minify",
     "build:main": "esbuild widget-src/code.tsx --bundle --outfile=dist/code.js",
     "build:ui": "npx vite build --minify esbuild --emptyOutDir=false",
-    "build:watch": "concurrently \"npm run build:main -- --watch\" \"npm run build:ui -- --watch\"",
-    "dev:ui": "npx vite"
+    "build:watch": "concurrently -n widget,iframe \"npm run build:main -- --watch\" \"npm run build:ui -- --watch\"",
+    "dev": "concurrently -n tsc,build,vite 'npm:tsc:watch' 'npm:build:watch' 'npm:dev:ui'"
   },
   "author": "Figma",
   "license": "MIT License",
@@ -23,8 +23,8 @@
     "react-dom": "^17.0.0"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "^1.37.0",
-    "@figma/widget-typings": "^1.0.0",
+    "@figma/plugin-typings": "*",
+    "@figma/widget-typings": "*",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",


### PR DESCRIPTION
- Add an `npm run dev` option that runs everything you want in development
- Add descriptive labels to the concurrently processes
- Update README.md